### PR TITLE
feat submission-history: fetch submission history for team

### DIFF
--- a/src/app/api/submission-history/route.ts
+++ b/src/app/api/submission-history/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { connectToDatabase } from "@/lib/db";
+import Team from "@/lib/models/team";
+import Question from "@/lib/models/question"; 
+
+export async function GET(req: NextRequest) {
+  const teamId = req.nextUrl.searchParams.get('teamId');
+  if (!teamId) {
+    return NextResponse.json({ error: 'Missing teamId' }, { status: 400 });
+  }
+
+  await connectToDatabase();
+
+  const team = await Team.findById(teamId).lean();
+  if (!team) {
+    return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+  }
+
+  type Difficulty = 'easy' | 'medium' | 'hard';
+
+  const r1Solved = team.round1?.questions_solved as Record<Difficulty, string[]> || { easy: [], medium: [], hard: [] };
+  const difficulties: Difficulty[] = ['easy', 'medium', 'hard'];
+  const solved: Array<{ questionId: string, difficulty: string, questionDescription: string | null }> = [];
+
+  for (const difficulty of difficulties) {
+    const questionIds: string[] = r1Solved[difficulty] || [];
+    for (const questionId of questionIds) {
+      const question = await Question.findById(questionId).lean();
+      solved.push({
+        questionId,
+        difficulty,
+        questionDescription: question?.question_description || null,
+      });
+    }
+  }
+
+  return NextResponse.json({
+    solved,
+  });
+}

--- a/src/lib/models/team.ts
+++ b/src/lib/models/team.ts
@@ -8,12 +8,12 @@ const TeamSchema = new Schema<ITeam>({
     round1: {
         questions_encountered: {
             easy: { type: [{type: String, ref: "Questions"}], default: [] },
-            midium: { type: [{type: String, ref: "Questions"}], default: [] },
+            medium: { type: [{type: String, ref: "Questions"}], default: [] },
             hard: { type: [{type: String, ref: "Questions"}], default: [] },
         },
         questions_solved: {
             easy: { type: [{type: String, ref: "Questions"}], default: [] },
-            midium: { type: [{type: String, ref: "Questions"}], default: [] },
+            medium: { type: [{type: String, ref: "Questions"}], default: [] },
             hard: { type: [{type: String, ref: "Questions"}], default: [] },
         },
         score: { type: Number, default: 0},
@@ -21,12 +21,12 @@ const TeamSchema = new Schema<ITeam>({
     round2: {
         questions_encountered: {
             easy: { type: [{type: String, ref: "Questions"}], default: [] },
-            midium: { type: [{type: String, ref: "Questions"}], default: [] },
+            medium: { type: [{type: String, ref: "Questions"}], default: [] },
             hard: { type: [{type: String, ref: "Questions"}], default: [] },
         },
         questions_solved: {
             easy: { type: [{type: String, ref: "Questions"}], default: [] },
-            midium: { type: [{type: String, ref: "Questions"}], default: [] },
+            medium: { type: [{type: String, ref: "Questions"}], default: [] },
             hard: { type: [{type: String, ref: "Questions"}], default: [] },
         },
         score: { type: Number, default: 0},


### PR DESCRIPTION
Added route for submission-history that fetches all the questions solved by a particular team. The team_id is given as search params.

example:
<img width="2204" height="147" alt="image" src="https://github.com/user-attachments/assets/109dfa51-607f-49a5-8813-10b34dc6ce4e" />
