### PR TITLE
feat & fix : added admin route pages, fixed routes to include secret strings and display them in the three leaderboard pages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@tanstack/react-table": "^8.21.3",
     "@types/bcryptjs": "^3.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/nodemailer": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.12)(react@19.1.0)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/bcryptjs':
         specifier: ^3.0.0
         version: 3.0.0
@@ -1502,6 +1505,17 @@ packages:
 
   '@tailwindcss/postcss@4.1.12':
     resolution: {integrity: sha512-5PpLYhCAwf9SJEeIsSmCDLgyVfdBhdBpzX1OJ87anT9IVR0Z9pjM0FNixCAUAHGnMBGB8K99SwAheXrT0Kh6QQ==}
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@tree-sitter-grammars/tree-sitter-yaml@0.7.1':
     resolution: {integrity: sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==}
@@ -5773,6 +5787,14 @@ snapshots:
       '@tailwindcss/oxide': 4.1.12
       postcss: 8.5.6
       tailwindcss: 4.1.12
+
+  '@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@tree-sitter-grammars/tree-sitter-yaml@0.7.1(tree-sitter@0.22.4)':
     dependencies:

--- a/src/app/admin/create-question/page.tsx
+++ b/src/app/admin/create-question/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function CreateQuestionPage() {
+  return (
+    <div>
+      Create Question Page
+    </div>
+  );
+}

--- a/src/app/admin/create-station/page.tsx
+++ b/src/app/admin/create-station/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function CreateStationPage() {
+  return (
+    <div>
+      Create Station Page
+    </div>
+  );
+}

--- a/src/app/admin/get-indoor-leaderboard/page.tsx
+++ b/src/app/admin/get-indoor-leaderboard/page.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import React, { useEffect, useState, useMemo } from "react";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+
+type Member = {
+  _id?: string;
+  name?: string;
+  username?: string;
+  email?: string;
+};
+
+type LeaderboardRow = {
+  name: string;
+  total_score: number;
+  members: (Member | string)[];
+  secret_string?: string;
+};
+
+export default function IndoorLeaderboardPage() {
+  const [leaderboardData, setLeaderboardData] = useState<LeaderboardRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [pageIndex, setPageIndex] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [searchQuery, setSearchQuery] = useState("");
+  const pageSize = 10;
+
+  // Force dark mode
+  useEffect(() => {
+    document.documentElement.classList.add("dark");
+    return () => document.documentElement.classList.remove("dark");
+  }, []);
+
+  const fetchLeaderboard = async (page: number) => {
+    try {
+      setLoading(true);
+      setError("");
+      const token = localStorage.getItem("token");
+
+      const res = await fetch(`/api/admin/get-indoor-Leaderboard?page=${page}`, {
+        headers: { Authorization: token ? `Bearer ${token}` : "" },
+      });
+
+      if (res.status === 401) {
+        setError("Unauthorized. Please log in as admin.");
+        setLeaderboardData([]);
+        return;
+      }
+      if (!res.ok) throw new Error("Failed to fetch leaderboard data");
+
+      const json = await res.json();
+      const totalCount = json.totalCount || 100;
+      setTotalPages(Math.ceil(totalCount / pageSize));
+
+      const normalizedData = (json.data || []).map((team: any) => ({
+        name: team.name || team.teamname,
+        total_score: team.total_score,
+        secret_string: team.secret_string || "",
+        members: (team.members || []).map((m: any) => (typeof m === "string" ? { _id: m } : m)),
+      }));
+
+      setLeaderboardData(normalizedData);
+    } catch (err) {
+      console.error("Leaderboard fetch error:", err);
+      setError("Unable to fetch leaderboard. Please try again later.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchLeaderboard(pageIndex);
+  }, [pageIndex]);
+
+  const filteredData = useMemo(() => {
+    if (!searchQuery.trim()) return leaderboardData;
+    return leaderboardData.filter((team) => {
+      const nameMatch = team.name.toLowerCase().includes(searchQuery.toLowerCase());
+      const memberMatch = team.members.some((m) => {
+        const member = typeof m === "string" ? { _id: m } : m;
+        return (
+          member.name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          member.username?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          member.email?.toLowerCase().includes(searchQuery.toLowerCase())
+        );
+      });
+      return nameMatch || memberMatch;
+    });
+  }, [searchQuery, leaderboardData]);
+
+  const columns: ColumnDef<LeaderboardRow>[] = [
+    {
+      id: "rank",
+      header: "Rank",
+      cell: ({ row }) => {
+        const rank = (pageIndex - 1) * pageSize + row.index + 1;
+        return <span className="font-semibold text-gray-100">{rank}</span>;
+      },
+    },
+    {
+      accessorKey: "name",
+      header: "Team Name",
+      cell: ({ getValue }) => <span className="font-medium text-white">{getValue<string>()}</span>,
+    },
+    {
+      accessorKey: "members",
+      header: "Members",
+      cell: ({ getValue }) => {
+        const members = getValue<(Member | string)[]>() || [];
+        if (!members.length) return <span className="text-gray-500 italic">No members</span>;
+        return (
+          <ul className="divide-y divide-gray-600">
+            {members.map((m, i) => {
+              const member = typeof m === "string" ? { _id: m } : m;
+              return (
+                <li key={i} className="py-1 px-2 text-sm truncate">
+                  {member.name || member.username || member.email || (member._id ? `User-${member._id}` : "Unknown")}
+                </li>
+              );
+            })}
+          </ul>
+        );
+      },
+    },
+    {
+      accessorKey: "total_score",
+      header: "Total Score",
+      cell: ({ getValue }) => <span className="font-bold text-blue-400 text-center">{getValue<number>()}</span>,
+    },
+    {
+      accessorKey: "secret_string",
+      header: "Secret String",
+      cell: ({ getValue }) => <span className="font-mono text-green-400">{getValue<string>() || "—"}</span>,
+    },
+  ];
+
+  const table = useReactTable({
+    data: filteredData,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  if (loading)
+    return (
+      <div className="flex justify-center items-center h-screen bg-gray-900">
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-gray-700 border-t-blue-500"></div>
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="p-8 min-h-screen bg-gray-900 flex items-center justify-center">
+        <p className="text-red-400 text-lg font-medium">{error}</p>
+      </div>
+    );
+
+  return (
+    <div className="p-8 min-h-screen bg-gray-900 text-gray-100">
+      <h1 className="mb-6 text-4xl font-extrabold text-center text-white">Indoor Leaderboard</h1>
+
+      {/* Search Bar */}
+      <div className="flex justify-end mb-4">
+        <input
+          type="text"
+          placeholder="Search team or member..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="px-4 py-2 rounded-md border border-gray-600 bg-gray-800 text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-xl shadow-lg border border-gray-700">
+        <table className="min-w-full border-collapse bg-gray-800 rounded-lg">
+          <thead className="bg-gray-700 text-gray-300">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    className="border-b border-gray-600 px-4 py-3 text-left font-semibold cursor-pointer select-none"
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    {header.column.getIsSorted() === "asc" && " ▲"}
+                    {header.column.getIsSorted() === "desc" && " ▼"}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="text-center py-6 text-gray-500 italic">
+                  No teams found
+                </td>
+              </tr>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <tr key={row.id} className="hover:bg-gray-700 transition-colors border-b border-gray-600">
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="px-4 py-3 align-top border-r border-gray-600 last:border-r-0">
+                      {cell.column.id === "members" ? (
+                        <ul className="divide-y divide-gray-600">
+                          {((cell.getValue() as (Member | string)[]) || []).map((m, i) => {
+                            const member = typeof m === "string" ? { _id: m } : m;
+                            return (
+                              <li key={i} className="py-1 px-2 text-sm truncate">
+                                {member.name || member.username || member.email || (member._id ? `User-${member._id}` : "Unknown")}
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      ) : (
+                        flexRender(cell.column.columnDef.cell, cell.getContext())
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex justify-center gap-4 mt-6">
+        <button
+          onClick={() => setPageIndex((prev) => Math.max(prev - 1, 1))}
+          disabled={pageIndex === 1}
+          className={`px-4 py-2 rounded-md border border-gray-700 ${
+            pageIndex === 1 ? "bg-gray-700 text-gray-500 cursor-not-allowed" : "bg-gray-800 text-gray-200 hover:bg-gray-700"
+          }`}
+        >
+          Previous
+        </button>
+        <span className="font-medium text-gray-300">
+          Page {pageIndex} of {totalPages}
+        </span>
+        <button
+          onClick={() => setPageIndex((prev) => Math.min(prev + 1, totalPages))}
+          disabled={pageIndex === totalPages}
+          className={`px-4 py-2 rounded-md border border-gray-700 ${
+            pageIndex === totalPages ? "bg-gray-700 text-gray-500 cursor-not-allowed" : "bg-gray-800 text-gray-200 hover:bg-gray-700"
+          }`}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/get-leaderboard/page.tsx
+++ b/src/app/admin/get-leaderboard/page.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import React, { useEffect, useState, useMemo } from "react";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+
+type Member = {
+  _id?: string;
+  name?: string;
+  username?: string;
+  email?: string;
+};
+
+type LeaderboardRow = {
+  name: string;
+  total_score: number;
+  members: (Member | string)[];
+  secret_string?: string;
+};
+
+export default function LeaderboardPage() {
+  const [leaderboardData, setLeaderboardData] = useState<LeaderboardRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [pageIndex, setPageIndex] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [searchQuery, setSearchQuery] = useState("");
+  const pageSize = 10;
+
+  useEffect(() => {
+    document.documentElement.classList.add("dark");
+    return () => document.documentElement.classList.remove("dark");
+  }, []);
+
+  const fetchLeaderboard = async (page: number) => {
+    try {
+      setLoading(true);
+      setError("");
+      const token = localStorage.getItem("token");
+
+      const res = await fetch(`/api/admin/get-Leaderboard?page=${page}`, {
+  headers: { Authorization: token ? `Bearer ${token}` : "" },
+});
+
+      if (res.status === 401) {
+        setError("Unauthorized. Please log in as admin.");
+        setLeaderboardData([]);
+        return;
+      }
+
+      if (!res.ok) throw new Error("Failed to fetch leaderboard data");
+
+      const json = await res.json();
+      setTotalPages(Math.ceil((json.totalCount || 100) / pageSize));
+
+      const normalizedData = (json.data || []).map((team: any) => ({
+        name: team.name,
+        total_score: team.total_score,
+        secret_string: team.secret_string || "",
+        members: (team.members || []).map((m: any) => (typeof m === "string" ? { _id: m } : m)),
+      }));
+
+      setLeaderboardData(normalizedData);
+    } catch (err) {
+      console.error("Leaderboard fetch error:", err);
+      setError("Unable to fetch leaderboard. Please try again later.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchLeaderboard(pageIndex);
+  }, [pageIndex]);
+
+  const filteredData = useMemo(() => {
+    if (!searchQuery.trim()) return leaderboardData;
+    return leaderboardData.filter((team) => {
+      const nameMatch = team.name.toLowerCase().includes(searchQuery.toLowerCase());
+      const memberMatch = team.members.some((m) => {
+        const member = typeof m === "string" ? { _id: m } : m;
+        return (
+          member.name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          member.username?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          member.email?.toLowerCase().includes(searchQuery.toLowerCase())
+        );
+      });
+      return nameMatch || memberMatch;
+    });
+  }, [searchQuery, leaderboardData]);
+
+  const columns: ColumnDef<LeaderboardRow>[] = [
+    {
+      id: "rank",
+      header: "Rank",
+      cell: ({ row }) => {
+        const rank = (pageIndex - 1) * pageSize + row.index + 1;
+        return <span className="font-semibold text-gray-100">{rank}</span>;
+      },
+    },
+    {
+      accessorKey: "name",
+      header: "Team Name",
+      cell: ({ getValue }) => <span className="font-medium text-white">{getValue<string>()}</span>,
+    },
+    {
+      accessorKey: "members",
+      header: "Members",
+      cell: ({ getValue }) => {
+        const members = getValue<(Member | string)[]>() || [];
+        if (!members.length) return <span className="text-gray-500 italic">No members</span>;
+        return (
+          <ul className="divide-y divide-gray-600">
+            {members.map((m, i) => {
+              const member = typeof m === "string" ? { _id: m } : m;
+              return (
+                <li key={i} className="py-1 px-2 text-sm truncate">
+                  {member.name || member.username || member.email || (member._id ? `User-${member._id}` : "Unknown")}
+                </li>
+              );
+            })}
+          </ul>
+        );
+      },
+    },
+    {
+      accessorKey: "total_score",
+      header: "Total Score",
+      cell: ({ getValue }) => <span className="font-bold text-blue-400 text-center">{getValue<number>()}</span>,
+    },
+    {
+      accessorKey: "secret_string",
+      header: "Secret String",
+      cell: ({ getValue }) => <span className="font-mono text-green-400">{getValue<string>() || "—"}</span>,
+    },
+  ];
+
+  const table = useReactTable({
+    data: filteredData,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  if (loading)
+    return (
+      <div className="flex justify-center items-center h-screen bg-gray-900">
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-gray-700 border-t-blue-500"></div>
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="p-8 min-h-screen bg-gray-900 flex items-center justify-center">
+        <p className="text-red-400 text-lg font-medium">{error}</p>
+      </div>
+    );
+
+  return (
+    <div className="p-8 min-h-screen bg-gray-900 text-gray-100">
+      <h1 className="mb-6 text-4xl font-extrabold text-center text-white">Leaderboard</h1>
+
+      {/* Search Bar */}
+      <div className="flex justify-end mb-4">
+        <input
+          type="text"
+          placeholder="Search team or member..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="px-4 py-2 rounded-md border border-gray-600 bg-gray-800 text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-xl shadow-lg border border-gray-700">
+        <table className="min-w-full border-collapse bg-gray-800 rounded-lg">
+          <thead className="bg-gray-700 text-gray-300">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    className="border-b border-gray-600 px-4 py-3 text-left font-semibold cursor-pointer select-none"
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    {header.column.getIsSorted() === "asc" && " ▲"}
+                    {header.column.getIsSorted() === "desc" && " ▼"}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="text-center py-6 text-gray-500 italic">
+                  No teams found
+                </td>
+              </tr>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <tr key={row.id} className="hover:bg-gray-700 transition-colors border-b border-gray-600">
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="px-4 py-3 align-top border-r border-gray-600 last:border-r-0">
+                      {cell.column.id === "members" ? (
+                        <ul className="divide-y divide-gray-600">
+                          {((cell.getValue() as (Member | string)[]) || []).map((m, i) => {
+                            const member = typeof m === "string" ? { _id: m } : m;
+                            return (
+                              <li key={i} className="py-1 px-2 text-sm truncate">
+                                {member.name || member.username || member.email || (member._id ? `User-${member._id}` : "Unknown")}
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      ) : (
+                        flexRender(cell.column.columnDef.cell, cell.getContext())
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex justify-center gap-4 mt-6">
+        <button
+          onClick={() => setPageIndex((prev) => Math.max(prev - 1, 1))}
+          disabled={pageIndex === 1}
+          className={`px-4 py-2 rounded-md border border-gray-700 ${
+            pageIndex === 1 ? "bg-gray-700 text-gray-500 cursor-not-allowed" : "bg-gray-800 text-gray-200 hover:bg-gray-700"
+          }`}
+        >
+          Previous
+        </button>
+        <span className="font-medium text-gray-300">
+          Page {pageIndex} of {totalPages}
+        </span>
+        <button
+          onClick={() => setPageIndex((prev) => Math.min(prev + 1, totalPages))}
+          disabled={pageIndex === totalPages}
+          className={`px-4 py-2 rounded-md border border-gray-700 ${
+            pageIndex === totalPages ? "bg-gray-700 text-gray-500 cursor-not-allowed" : "bg-gray-800 text-gray-200 hover:bg-gray-700"
+          }`}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/get-outdoor-leaderboard/page.tsx
+++ b/src/app/admin/get-outdoor-leaderboard/page.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import React, { useEffect, useState, useMemo } from "react";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+
+type Member = {
+  _id?: string;
+  name?: string;
+  username?: string;
+  email?: string;
+};
+
+type LeaderboardRow = {
+  name: string;
+  total_score: number;
+  members: (Member | string)[];
+  secret_string?: string; // added secret_string
+};
+
+export default function OutdoorLeaderboardPage() {
+  const [leaderboardData, setLeaderboardData] = useState<LeaderboardRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [pageIndex, setPageIndex] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [searchQuery, setSearchQuery] = useState("");
+  const pageSize = 10;
+
+  // Force dark mode
+  useEffect(() => {
+    document.documentElement.classList.add("dark");
+    return () => document.documentElement.classList.remove("dark");
+  }, []);
+
+  const fetchLeaderboard = async (page: number) => {
+    try {
+      setLoading(true);
+      setError("");
+      const token = localStorage.getItem("token");
+
+      const res = await fetch(`/api/admin/get-outdoor-Leaderboard?page=${page}`, {
+        headers: { Authorization: token ? `Bearer ${token}` : "" },
+      });
+
+      if (res.status === 401) {
+        setError("Unauthorized. Please log in as admin.");
+        setLeaderboardData([]);
+        return;
+      }
+      if (!res.ok) throw new Error("Failed to fetch leaderboard data");
+
+      const json = await res.json();
+      const totalCount = json.totalCount || 100;
+      setTotalPages(Math.ceil(totalCount / pageSize));
+
+      const normalizedData = (json.data || []).map((team: any) => ({
+        name: team.name,
+        total_score: team.total_score,
+        secret_string: team.secret_string || "",
+        members: (team.members || []).map((m: any) => (typeof m === "string" ? { _id: m } : m)),
+      }));
+
+      setLeaderboardData(normalizedData);
+    } catch (err) {
+      console.error("Leaderboard fetch error:", err);
+      setError("Unable to fetch leaderboard. Please try again later.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchLeaderboard(pageIndex);
+  }, [pageIndex]);
+
+  const filteredData = useMemo(() => {
+    if (!searchQuery.trim()) return leaderboardData;
+    return leaderboardData.filter((team) => {
+      const nameMatch = team.name.toLowerCase().includes(searchQuery.toLowerCase());
+      const memberMatch = team.members.some((m) => {
+        const member = typeof m === "string" ? { _id: m } : m;
+        return (
+          member.name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          member.username?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          member.email?.toLowerCase().includes(searchQuery.toLowerCase())
+        );
+      });
+      return nameMatch || memberMatch;
+    });
+  }, [searchQuery, leaderboardData]);
+
+  const columns: ColumnDef<LeaderboardRow>[] = [
+    {
+      id: "rank",
+      header: "Rank",
+      cell: ({ row }) => {
+        const rank = (pageIndex - 1) * pageSize + row.index + 1;
+        return <span className="font-semibold text-gray-100">{rank}</span>;
+      },
+    },
+    {
+      accessorKey: "name",
+      header: "Team Name",
+      cell: ({ getValue }) => <span className="font-medium text-white">{getValue<string>()}</span>,
+    },
+    {
+      accessorKey: "members",
+      header: "Members",
+      cell: ({ getValue }) => {
+        const members = getValue<(Member | string)[]>() || [];
+        if (!members.length) return <span className="text-gray-500 italic">No members</span>;
+        return (
+          <ul className="divide-y divide-gray-600">
+            {members.map((m, i) => {
+              const member = typeof m === "string" ? { _id: m } : m;
+              return (
+                <li key={i} className="py-1 px-2 text-sm truncate">
+                  {member.name || member.username || member.email || (member._id ? `User-${member._id}` : "Unknown")}
+                </li>
+              );
+            })}
+          </ul>
+        );
+      },
+    },
+    {
+      accessorKey: "total_score",
+      header: "Total Score",
+      cell: ({ getValue }) => <span className="font-bold text-blue-400 text-center">{getValue<number>()}</span>,
+    },
+    {
+      accessorKey: "secret_string",
+      header: "Secret String",
+      cell: ({ getValue }) => <span className="font-mono text-green-400">{getValue<string>() || "—"}</span>,
+    },
+  ];
+
+  const table = useReactTable({
+    data: filteredData,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  if (loading)
+    return (
+      <div className="flex justify-center items-center h-screen bg-gray-900">
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-gray-700 border-t-blue-500"></div>
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="p-8 min-h-screen bg-gray-900 flex items-center justify-center">
+        <p className="text-red-400 text-lg font-medium">{error}</p>
+      </div>
+    );
+
+  return (
+    <div className="p-8 min-h-screen bg-gray-900 text-gray-100">
+      <h1 className="mb-6 text-4xl font-extrabold text-center text-white">Outdoor Leaderboard</h1>
+
+      {/* Search Bar */}
+      <div className="flex justify-end mb-4">
+        <input
+          type="text"
+          placeholder="Search team or member..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="px-4 py-2 rounded-md border border-gray-600 bg-gray-800 text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-xl shadow-lg border border-gray-700">
+        <table className="min-w-full border-collapse bg-gray-800 rounded-lg">
+          <thead className="bg-gray-700 text-gray-300">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    className="border-b border-gray-600 px-4 py-3 text-left font-semibold cursor-pointer select-none"
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    {header.column.getIsSorted() === "asc" && " ▲"}
+                    {header.column.getIsSorted() === "desc" && " ▼"}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="text-center py-6 text-gray-500 italic">
+                  No teams found
+                </td>
+              </tr>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <tr key={row.id} className="hover:bg-gray-700 transition-colors border-b border-gray-600">
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="px-4 py-3 align-top border-r border-gray-600 last:border-r-0">
+                      {cell.column.id === "members" ? (
+                        <ul className="divide-y divide-gray-600">
+                          {((cell.getValue() as (Member | string)[]) || []).map((m, i) => {
+                            const member = typeof m === "string" ? { _id: m } : m;
+                            return (
+                              <li key={i} className="py-1 px-2 text-sm truncate">
+                                {member.name || member.username || member.email || (member._id ? `User-${member._id}` : "Unknown")}
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      ) : (
+                        flexRender(cell.column.columnDef.cell, cell.getContext())
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex justify-center gap-4 mt-6">
+        <button
+          onClick={() => setPageIndex((prev) => Math.max(prev - 1, 1))}
+          disabled={pageIndex === 1}
+          className={`px-4 py-2 rounded-md border border-gray-700 ${
+            pageIndex === 1 ? "bg-gray-700 text-gray-500 cursor-not-allowed" : "bg-gray-800 text-gray-200 hover:bg-gray-700"
+          }`}
+        >
+          Previous
+        </button>
+        <span className="font-medium text-gray-300">
+          Page {pageIndex} of {totalPages}
+        </span>
+        <button
+          onClick={() => setPageIndex((prev) => Math.min(prev + 1, totalPages))}
+          disabled={pageIndex === totalPages}
+          className={`px-4 py-2 rounded-md border border-gray-700 ${
+            pageIndex === totalPages ? "bg-gray-700 text-gray-500 cursor-not-allowed" : "bg-gray-800 text-gray-200 hover:bg-gray-700"
+          }`}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/update-round/page.tsx
+++ b/src/app/admin/update-round/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function UpdateRoundPage() {
+  return (
+    <div>
+      Create Update Round Page
+    </div>
+  );
+}

--- a/src/app/api/admin/get-Leaderboard/route.ts
+++ b/src/app/api/admin/get-Leaderboard/route.ts
@@ -3,35 +3,45 @@ import { getUserFromToken } from "@/utils/getUserFromToken";
 import { NextRequest, NextResponse } from "next/server";
 import Team from "@/lib/models/team";
 
-export async function GET(req:NextRequest) {
-    try {
-        await connectToDatabase();
-        const tUser = await getUserFromToken(req);
-        if (!tUser){
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-        if (tUser.role !== "admin") {
-            return NextResponse.json({ error: "Access denied" }, { status: 403 });
-        }
+export async function GET(req: NextRequest) {
+  try {
+    await connectToDatabase();
+    const tUser = await getUserFromToken(req);
 
-        const { searchParams } = new URL(req.url);
-        const page = searchParams.get('page');
-        if(!page){
-            return NextResponse.json({ error: "provide the Page number" }, { status: 400 });
-        }
-
-        const teams = await Team.find({}).sort({ total_score: -1 }).skip((+page-1)*10).limit(10);
-
-        const leaderboard = teams.map((team: any, index: number) => ({
-            rank: index + 1,
-            name: team.teamname,
-            Team_score: team.total_score,
-            members: team.members || [],
-        }));
-
-        return NextResponse.json({ message: "Leaderboard fetched successfully", data: leaderboard }, { status: 200 });
-    } catch (error) {
-        console.error("Error in GET /api/admin/get-outdoor-Leaderboard", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    if (!tUser) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    if (tUser.role !== "admin") {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const page = searchParams.get("page");
+
+    if (!page) {
+      return NextResponse.json({ error: "Provide the page number" }, { status: 400 });
+    }
+
+    const teams = await Team.find({})
+      .sort({ total_score: -1 })
+      .skip((+page - 1) * 10)
+      .limit(10);
+
+    const leaderboard = teams.map((team: any, index: number) => ({
+      rank: index + 1,
+      name: team.teamname,
+      total_score: team.total_score,
+      secret_string: team.secret_string || "", // added secret_string over here..empty for now cuz not added in db
+      members: team.members || [],
+    }));
+
+    return NextResponse.json(
+      { message: "Leaderboard fetched successfully", data: leaderboard, totalCount: await Team.countDocuments() },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error in GET /api/admin/getLeaderboard", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
 }

--- a/src/app/api/admin/get-indoor-Leaderboard/route.ts
+++ b/src/app/api/admin/get-indoor-Leaderboard/route.ts
@@ -3,48 +3,52 @@ import { getUserFromToken } from "@/utils/getUserFromToken";
 import { NextRequest, NextResponse } from "next/server";
 import Team from "@/lib/models/team";
 
-export async function GET(req:NextRequest) {
-    try {
-        await connectToDatabase();
+export async function GET(req: NextRequest) {
+  try {
+    await connectToDatabase();
 
-        const tUser = await getUserFromToken(req);
-        if (!tUser){
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-        if (tUser.role !== "admin") {
-            return NextResponse.json({ error: "Access denied" }, { status: 403 });
-        }
-
-        const { searchParams } = new URL(req.url);
-        const page = searchParams.get('page');
-        if(!page){
-            return NextResponse.json({ error: "provide the Page number" }, { status: 400 });
-        }
-
-        const teams = await Team.aggregate([{
-            $project:{
-                teamname:1,
-                members:1,
-                total_score: {$add : ["$round1.indoor_score","$round2.indoor_score"]}
-            }
-        },{
-            $sort: {total_score: -1}
-        },{
-            $skip: (+page-1)*10
-        },{
-            $limit: 10
-        }]);
-
-        const leaderboard = teams.map((team: any, index: number) => ({
-            rank: index + 1,
-            name: team.teamname,
-            total_score: team.total_score,
-            members: team.members || [],
-        }));
-
-        return NextResponse.json({ message: "Leaderboard fetched successfully", data: leaderboard }, { status: 200 });
-    } catch (error) {
-        console.error("Error in GET /api/admin/get-outdoor-Leaderboard", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    const tUser = await getUserFromToken(req);
+    if (!tUser) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+    if (tUser.role !== "admin") {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const page = searchParams.get("page");
+    if (!page) {
+      return NextResponse.json({ error: "Provide the page number" }, { status: 400 });
+    }
+
+    const teams = await Team.aggregate([
+      {
+        $project: {
+          teamname: 1,
+          members: 1,
+          total_score: { $add: ["$round1.indoor_score", "$round2.indoor_score"] },
+          secret_string: "$round2.secret_string", // add this line
+        },
+      },
+      { $sort: { total_score: -1 } },
+      { $skip: (+page - 1) * 10 },
+      { $limit: 10 },
+    ]);
+
+    const leaderboard = teams.map((team: any, index: number) => ({
+      rank: index + 1,
+      name: team.teamname,
+      total_score: team.total_score,
+      members: team.members || [],
+      secret_string: team.secret_string || "", // fallback if undefined
+    }));
+
+    return NextResponse.json(
+      { message: "Leaderboard fetched successfully", data: leaderboard },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error in GET /api/admin/get-indoor-Leaderboard", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
 }

--- a/src/app/api/admin/get-outdoor-Leaderboard/route.ts
+++ b/src/app/api/admin/get-outdoor-Leaderboard/route.ts
@@ -3,48 +3,52 @@ import { getUserFromToken } from "@/utils/getUserFromToken";
 import { NextRequest, NextResponse } from "next/server";
 import Team from "@/lib/models/team";
 
-export async function GET(req:NextRequest) {
-    try {
-        await connectToDatabase();
+export async function GET(req: NextRequest) {
+  try {
+    await connectToDatabase();
 
-        const tUser = await getUserFromToken(req);
-        if (!tUser){
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-        if (tUser.role !== "admin") {
-            return NextResponse.json({ error: "Access denied" }, { status: 403 });
-        }
-
-        const { searchParams } = new URL(req.url);
-        const page = searchParams.get('page');
-        if(!page){
-            return NextResponse.json({ error: "provide the Page number" }, { status: 400 });
-        }
-
-        const teams = await Team.aggregate([{
-            $project:{
-                teamname:1,
-                members:1,
-                total_score: {$add : ["$round1.score","$round2.score"]}
-            }
-        },{
-            $sort: {total_score: -1}
-        },{
-            $skip: (+page-1)*10
-        },{
-            $limit: 10
-        }]);
-
-        const leaderboard = teams.map((team: any, index: number) => ({
-            rank: index + 1,
-            name: team.teamname,
-            total_score: team.total_score,
-            members: team.members || [],
-        }));
-
-        return NextResponse.json({ message: "Leaderboard fetched successfully", data: leaderboard }, { status: 200 });
-    } catch (error) {
-        console.error("Error in GET /api/admin/get-outdoor-Leaderboard", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    const tUser = await getUserFromToken(req);
+    if (!tUser) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+    if (tUser.role !== "admin") {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const page = searchParams.get("page");
+    if (!page) {
+      return NextResponse.json({ error: "Provide the page number" }, { status: 400 });
+    }
+
+    const teams = await Team.aggregate([
+      {
+        $project: {
+          teamname: 1,
+          members: 1,
+          total_score: { $add: ["$round1.score", "$round2.score"] },
+          secret_string: "$round2.secret_string", // include secret_string
+        },
+      },
+      { $sort: { total_score: -1 } },
+      { $skip: (+page - 1) * 10 },
+      { $limit: 10 },
+    ]);
+
+    const leaderboard = teams.map((team: any, index: number) => ({
+      rank: index + 1,
+      name: team.teamname,
+      total_score: team.total_score,
+      members: team.members || [],
+      secret_string: team.secret_string || "", 
+    }));
+
+    return NextResponse.json(
+      { message: "Leaderboard fetched successfully", data: leaderboard },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error in GET /api/admin/get-outdoor-Leaderboard", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
 }

--- a/src/components/LayoutWrapper.tsx
+++ b/src/components/LayoutWrapper.tsx
@@ -14,6 +14,7 @@ export default function LayoutClientWrapper({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+
   const rethinkPages = [
     "/login",
     "/create-team",
@@ -23,22 +24,19 @@ export default function LayoutClientWrapper({
     "/verifyemail",
     "/hell-instructions",
   ];
-  const docsPage = pathname.startsWith("/docs");
+
+  const isDocsPage = pathname.startsWith("/docs");
   const isRethinkPage = rethinkPages.some((page) => pathname.startsWith(page));
+  const isAdminPage = pathname.startsWith("/admin");
+
   const [isDesktop, setIsDesktop] = useState(false);
   const [installPrompt, setInstallPrompt] = useState<any>(null);
 
   useEffect(() => {
-    const checkDevice = () => {
-      setIsDesktop(window.innerWidth >= 768);
-    };
-
+    const checkDevice = () => setIsDesktop(window.innerWidth >= 768);
     checkDevice();
     window.addEventListener("resize", checkDevice);
-
-    return () => {
-      window.removeEventListener("resize", checkDevice);
-    };
+    return () => window.removeEventListener("resize", checkDevice);
   }, []);
 
   useEffect(() => {
@@ -58,19 +56,13 @@ export default function LayoutClientWrapper({
     window.addEventListener("appinstalled", handleAppInstalled);
 
     return () => {
-      window.removeEventListener(
-        "beforeinstallprompt",
-        handleBeforeInstallPrompt
-      );
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
       window.removeEventListener("appinstalled", handleAppInstalled);
     };
   }, []);
 
-  if (docsPage) {
-    return <>{children}</>;
-  }
-
-  if (isDesktop && !isRethinkPage) {
+ 
+  if (!isAdminPage && !isRethinkPage && !isDocsPage && isDesktop) {
     return (
       <body className={`${pixelFont.variable} font-pixel`}>
         <div className="flex flex-col items-center justify-center h-screen bg-black text-white text-center p-8">
@@ -94,9 +86,7 @@ export default function LayoutClientWrapper({
   }
 
   const handleInstallClick = async () => {
-    if (!installPrompt) {
-      return;
-    }
+    if (!installPrompt) return;
     installPrompt.prompt();
     await installPrompt.userChoice;
     setInstallPrompt(null);
@@ -110,20 +100,29 @@ export default function LayoutClientWrapper({
           : `${pixelFont.variable} font-pixel relative min-h-screen`
       }`}
     >
-      <Image
-        src="/assets/background.svg"
-        alt="Background"
-        className="absolute w-full h-full object-cover z-0 "
-        width={100}
-        height={100}
-        priority
-      />
+      
+      {!isAdminPage && (
+        <Image
+          src="/assets/background.svg"
+          alt="Background"
+          className="absolute w-full h-full object-cover z-0"
+          width={100}
+          height={100}
+          priority
+        />
+      )}
 
       {isRethinkPage ? (
         <div className="relative z-20 min-h-screen overflow-y-auto">
           {children}
         </div>
+      ) : isAdminPage ? (
+        
+        <div className="relative z-20 min-h-screen bg-gray-900 text-gray-100 flex flex-col p-6">
+          <main className="flex-1 overflow-y-auto">{children}</main>
+        </div>
       ) : (
+        
         <div className="grid grid-rows-[10%_1fr_15%] h-screen">
           <div className="z-30 relative">
             <TopNav />
@@ -135,7 +134,7 @@ export default function LayoutClientWrapper({
         </div>
       )}
 
-      {installPrompt && (
+      {installPrompt && !isAdminPage && (
         <motion.button
           onClick={handleInstallClick}
           className="fixed bottom-24 right-4 z-50 flex items-center justify-center gap-2 text-white font-bold rounded-full shadow-lg hover:brightness-50 bg-cover h-14 w-40 px-6"


### PR DESCRIPTION
1. leaderboards page 
<img width="1429" height="767" alt="image" src="https://github.com/user-attachments/assets/d0f00770-b3db-4fcc-bab5-e3d85611fb96" />


2. indoor leaderboards
<img width="1429" height="767" alt="image" src="https://github.com/user-attachments/assets/17bd4a50-b735-4247-aece-27d90e971e39" />

3. outdoor leaderboard
<img width="1429" height="767" alt="image" src="https://github.com/user-attachments/assets/6b7a671f-0f86-46fb-95d0-6f782a427863" />
